### PR TITLE
Fix Cross-References

### DIFF
--- a/inferno/bnn/modules/attention.py
+++ b/inferno/bnn/modules/attention.py
@@ -142,7 +142,7 @@ class MultiheadAttention(BNNMixin, nn.Module):
                 A float mask of the same type as query, key, value that is added to the attention score.
         :param is_causal: If set to true, the attention masking is a lower triangular matrix when the mask is a
                 square matrix. The attention masking has the form of the upper left causal bias due to the alignment
-                (see :class:`~torch.nn.attention.bias.CausalBias`) when the mask is a non-square matrix.
+                (see [``torch.nn.attention.bias.CausalBias``][]) when the mask is a non-square matrix.
                 An error is thrown if both ``attn_mask`` and ``is_causal`` are set.
         :param sample_shape: Shape of samples.
         :param generator: Random number generator.

--- a/inferno/bnn/modules/containers/sequential.py
+++ b/inferno/bnn/modules/containers/sequential.py
@@ -33,7 +33,7 @@ class Sequential(BNNMixin, nn.Sequential):
     :param *args: Any number of modules to add to the container.
     :param parametrization: The parametrization to use. If `None`, the
         parametrization of the modules in the container will be used. If
-        a :class:`~inferno.bnn.params.Parametrization` object is passed,
+        a [``Parametrization``][inferno.bnn.params.Parametrization] object is passed,
         it will be used for all modules in the container.
     """
 

--- a/inferno/models/resnet.py
+++ b/inferno/models/resnet.py
@@ -674,7 +674,7 @@ class Bottleneck(bnn.BNNMixin, nn.Module):
 class ResNet18(ResNet):
     """ResNet-18
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -709,7 +709,7 @@ class ResNet18(ResNet):
 class ResNet34(ResNet):
     """ResNet-34
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -744,7 +744,7 @@ class ResNet34(ResNet):
 class ResNet50(ResNet):
     """ResNet-50
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -779,7 +779,7 @@ class ResNet50(ResNet):
 class ResNet101(ResNet):
     """ResNet-101
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -814,7 +814,7 @@ class ResNet101(ResNet):
 class ResNeXt50_32X4D(ResNet):
     """ResNext-50 (32x4d)
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -854,7 +854,7 @@ class ResNeXt50_32X4D(ResNet):
 class ResNeXt101_32X8D(ResNet):
     """ResNext-101 (32x8d)
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -894,7 +894,7 @@ class ResNeXt101_32X8D(ResNet):
 class ResNeXt101_64X4D(ResNet):
     """ResNext-101 (32x4d)
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -937,7 +937,7 @@ class WideResNet50(ResNet):
     Architecture described in [Wide Residual Networks](https://arxiv.org/abs/1605.06431). The model is the same
     as a ResNet except for the bottleneck number of channels which is twice larger in every block.
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(
@@ -979,7 +979,7 @@ class WideResNet101(ResNet):
     Architecture described in [Wide Residual Networks](https://arxiv.org/abs/1605.06431). The model is the same
     as a ResNet except for the bottleneck number of channels which is twice larger in every block.
 
-    :param **kwargs: Additional keyword arguments passed on to :class:`~inferno.bnn.models.ResNet`.
+    :param **kwargs: Additional keyword arguments passed on to [``ResNet``][inferno.models.ResNet].
     """
 
     def __init__(


### PR DESCRIPTION
This PR fixes the syntax for cross references in the documentation. The cross references to other API documentation (e.g. PyTorch) or other parts of the inferno documentation where not using the correct syntax and thus were broken. This PR fixes this.